### PR TITLE
Memory allocator

### DIFF
--- a/VectorMath.xcodeproj/project.pbxproj
+++ b/VectorMath.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D800BD941D205EFA00703B7C /* MemoryRecylcing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BD931D205EFA00703B7C /* MemoryRecylcing.swift */; };
 		D85696271D1D77C200FDD6C4 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85696261D1D77C200FDD6C4 /* Vector.swift */; };
 		D856962B1D1D84D400FDD6C4 /* Memory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D856962A1D1D84D400FDD6C4 /* Memory.swift */; };
 		D86008191D43D07700B0BC53 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86008181D43D07700B0BC53 /* Assertions.swift */; };
@@ -48,6 +49,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D800BD931D205EFA00703B7C /* MemoryRecylcing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemoryRecylcing.swift; path = Internal/MemoryRecylcing.swift; sourceTree = "<group>"; };
 		D85696261D1D77C200FDD6C4 /* Vector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Vector.swift; path = Protocols/Vector.swift; sourceTree = "<group>"; };
 		D856962A1D1D84D400FDD6C4 /* Memory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Memory.swift; path = Protocols/Memory.swift; sourceTree = "<group>"; };
 		D86008181D43D07700B0BC53 /* Assertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assertions.swift; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 				D8CB58691D1C44730018E323 /* ManagedMemory.swift */,
 				D88796211D430C5B009439EB /* ManagedMemorySplitComplex.swift */,
 				D88796231D430C8E009439EB /* ManagedMemorySplitComplexDouble.swift */,
+				D800BD931D205EFA00703B7C /* MemoryRecylcing.swift */,
 			);
 			name = Internal;
 			sourceTree = "<group>";
@@ -310,7 +313,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "MaxMo Technologies LLC";
 				TargetAttributes = {
 					D8CB584D1D1C43CD0018E323 = {
@@ -374,6 +377,7 @@
 				D8AAE29A1D7076480017AC38 /* VectorFloat.swift in Sources */,
 				D8AAE29D1D7076910017AC38 /* CircularBuffer.swift in Sources */,
 				D856962B1D1D84D400FDD6C4 /* Memory.swift in Sources */,
+				D800BD941D205EFA00703B7C /* MemoryRecylcing.swift in Sources */,
 				D85696271D1D77C200FDD6C4 /* Vector.swift in Sources */,
 				D8CB586A1D1C44730018E323 /* ManagedMemory.swift in Sources */,
 				D8AAE2971D7076480017AC38 /* VectorComplexDouble.swift in Sources */,
@@ -428,8 +432,10 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -478,8 +484,10 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";

--- a/VectorMath.xcodeproj/project.pbxproj
+++ b/VectorMath.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D800BD941D205EFA00703B7C /* MemoryRecylcing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BD931D205EFA00703B7C /* MemoryRecylcing.swift */; };
 		D85696271D1D77C200FDD6C4 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85696261D1D77C200FDD6C4 /* Vector.swift */; };
 		D856962B1D1D84D400FDD6C4 /* Memory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D856962A1D1D84D400FDD6C4 /* Memory.swift */; };
 		D86008191D43D07700B0BC53 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86008181D43D07700B0BC53 /* Assertions.swift */; };
@@ -36,6 +35,9 @@
 		D8CB58591D1C43CD0018E323 /* VectorMath.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8CB584E1D1C43CD0018E323 /* VectorMath.framework */; };
 		D8CB586A1D1C44730018E323 /* ManagedMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB58691D1C44730018E323 /* ManagedMemory.swift */; };
 		D8CB586D1D1C45A10018E323 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8CB586C1D1C45A10018E323 /* Accelerate.framework */; };
+		D8FFBC0D1E357C78007B85CE /* Malloc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FFBC0C1E357C78007B85CE /* Malloc.swift */; };
+		D8FFBC0F1E357CC0007B85CE /* Allocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FFBC0E1E357CC0007B85CE /* Allocator.swift */; };
+		D8FFBC111E357E34007B85CE /* SimpleSegregatedStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FFBC101E357E34007B85CE /* SimpleSegregatedStorage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,7 +51,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		D800BD931D205EFA00703B7C /* MemoryRecylcing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemoryRecylcing.swift; path = Internal/MemoryRecylcing.swift; sourceTree = "<group>"; };
 		D85696261D1D77C200FDD6C4 /* Vector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Vector.swift; path = Protocols/Vector.swift; sourceTree = "<group>"; };
 		D856962A1D1D84D400FDD6C4 /* Memory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Memory.swift; path = Protocols/Memory.swift; sourceTree = "<group>"; };
 		D86008181D43D07700B0BC53 /* Assertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assertions.swift; sourceTree = "<group>"; };
@@ -82,6 +83,9 @@
 		D8CB585F1D1C43CD0018E323 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D8CB58691D1C44730018E323 /* ManagedMemory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ManagedMemory.swift; path = Internal/ManagedMemory.swift; sourceTree = "<group>"; };
 		D8CB586C1D1C45A10018E323 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		D8FFBC0C1E357C78007B85CE /* Malloc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Malloc.swift; path = Internal/Allocators/Malloc.swift; sourceTree = "<group>"; };
+		D8FFBC0E1E357CC0007B85CE /* Allocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Allocator.swift; path = Internal/Allocators/Allocator.swift; sourceTree = "<group>"; };
+		D8FFBC101E357E34007B85CE /* SimpleSegregatedStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SimpleSegregatedStorage.swift; path = Internal/Allocators/SimpleSegregatedStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -237,12 +241,12 @@
 		D8CB58681D1C444C0018E323 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				D8FFBC0B1E357C63007B85CE /* Allocators */,
 				D8B60A331D6E2FAE001FD6A3 /* TPCircularBuffer */,
 				D8B60A381D6E316D001FD6A3 /* CircularMemory.swift */,
 				D8CB58691D1C44730018E323 /* ManagedMemory.swift */,
 				D88796211D430C5B009439EB /* ManagedMemorySplitComplex.swift */,
 				D88796231D430C8E009439EB /* ManagedMemorySplitComplexDouble.swift */,
-				D800BD931D205EFA00703B7C /* MemoryRecylcing.swift */,
 			);
 			name = Internal;
 			sourceTree = "<group>";
@@ -253,6 +257,16 @@
 				D8CB586C1D1C45A10018E323 /* Accelerate.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D8FFBC0B1E357C63007B85CE /* Allocators */ = {
+			isa = PBXGroup;
+			children = (
+				D8FFBC0E1E357CC0007B85CE /* Allocator.swift */,
+				D8FFBC0C1E357C78007B85CE /* Malloc.swift */,
+				D8FFBC101E357E34007B85CE /* SimpleSegregatedStorage.swift */,
+			);
+			name = Allocators;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -373,11 +387,12 @@
 			files = (
 				D88796201D430BEF009439EB /* VectorSummarizable.swift in Sources */,
 				D887962A1D430F5B009439EB /* ComplexDouble.swift in Sources */,
+				D8FFBC111E357E34007B85CE /* SimpleSegregatedStorage.swift in Sources */,
 				D8B60A361D6E2FDD001FD6A3 /* TPCircularBuffer.c in Sources */,
 				D8AAE29A1D7076480017AC38 /* VectorFloat.swift in Sources */,
 				D8AAE29D1D7076910017AC38 /* CircularBuffer.swift in Sources */,
+				D8FFBC0D1E357C78007B85CE /* Malloc.swift in Sources */,
 				D856962B1D1D84D400FDD6C4 /* Memory.swift in Sources */,
-				D800BD941D205EFA00703B7C /* MemoryRecylcing.swift in Sources */,
 				D85696271D1D77C200FDD6C4 /* Vector.swift in Sources */,
 				D8CB586A1D1C44730018E323 /* ManagedMemory.swift in Sources */,
 				D8AAE2971D7076480017AC38 /* VectorComplexDouble.swift in Sources */,
@@ -388,6 +403,7 @@
 				D8AAE2981D7076480017AC38 /* VectorComplexFloat.swift in Sources */,
 				D88796241D430C8E009439EB /* ManagedMemorySplitComplexDouble.swift in Sources */,
 				D8B60A391D6E316E001FD6A3 /* CircularMemory.swift in Sources */,
+				D8FFBC0F1E357CC0007B85CE /* Allocator.swift in Sources */,
 				D88796261D430CB7009439EB /* ComplexFloat.swift in Sources */,
 				D8AAE2991D7076480017AC38 /* VectorDouble.swift in Sources */,
 			);

--- a/VectorMath.xcodeproj/xcuserdata/nathan.xcuserdatad/xcschemes/VectorMath.xcscheme
+++ b/VectorMath.xcodeproj/xcuserdata/nathan.xcuserdatad/xcschemes/VectorMath.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/VectorMath/Internal/Allocators/Allocator.swift
+++ b/VectorMath/Internal/Allocators/Allocator.swift
@@ -1,0 +1,15 @@
+//
+//  Allocator.swift
+//  VectorMath
+//
+//  Created by Nathan Perkins on 1/22/17.
+//  Copyright © 2017 MaxMo Technologies LLC. All rights reserved.
+//
+
+import Foundation
+
+internal protocol Allocator
+{
+    func allocateMemory(bytes: Int, alignment: Int) -> UnsafeMutableRawPointer
+    func deallocateMemory(pointer: UnsafeMutableRawPointer, bytes: Int, alignment: Int)
+}

--- a/VectorMath/Internal/Allocators/Malloc.swift
+++ b/VectorMath/Internal/Allocators/Malloc.swift
@@ -1,0 +1,20 @@
+//
+//  AllocatorMalloc.swift
+//  VectorMath
+//
+//  Created by Nathan Perkins on 1/22/17.
+//  Copyright © 2017 MaxMo Technologies LLC. All rights reserved.
+//
+
+import Foundation
+
+internal final class AllocatorMalloc: Allocator
+{
+    func allocateMemory(bytes: Int, alignment: Int) -> UnsafeMutableRawPointer {
+        return UnsafeMutableRawPointer.allocate(bytes: bytes, alignedTo: alignment)
+    }
+    
+    func deallocateMemory(pointer: UnsafeMutableRawPointer, bytes: Int, alignment: Int) {
+        pointer.deallocate(bytes: bytes, alignedTo: alignment)
+    }
+}

--- a/VectorMath/Internal/Allocators/SimpleSegregatedStorage.swift
+++ b/VectorMath/Internal/Allocators/SimpleSegregatedStorage.swift
@@ -8,79 +8,142 @@
 
 import Foundation
 
-private struct MemorySignature: Equatable, Hashable
+let kDefaultPageAlignment = 8
+
+fileprivate struct Chunk
 {
-    let length: Int
-    let size: Int
+    var next: UnsafeMutablePointer<Chunk>?
+}
+
+fileprivate class AllocatorPage
+{
+    var chunkBytes: Int
+    var chunkCount: Int = 0
+    var pageBytes: Int = 0
     
-    var hashValue: Int {
-        return length.hashValue ^ size.hashValue
+    var firstFree: UnsafeMutablePointer<Chunk>?
+    
+    init(chunkBytes: Int, chunkCount: Int=0) {
+        // chunk bytes
+        self.chunkBytes = chunkBytes
+        
+        // extend
+        if chunkCount > 0 {
+            extendBy(additionalChunks: chunkCount)
+        }
     }
     
-    var totalSize: Int {
-        return length * size
+    init(chunkBytes: Int, pageBytes: Int) {
+        // chunk bytes
+        self.chunkBytes = chunkBytes
+        
+        // extend
+        if pageBytes > 0 {
+            extendBy(additionalBytes: pageBytes)
+        }
+    }
+    
+    func extendBy(additionalBytes: Int) {
+        extendBy(additionalChunks: additionalBytes / (chunkBytes + MemoryLayout<Chunk>.stride))
+    }
+    
+    // NOT THREAD SAFE AT ALL
+    func extendBy(additionalChunks: Int) {
+        print("\(additionalChunks) x \(chunkBytes)")
+        
+        // must be positive number of chunks
+        guard additionalChunks > 0 else { return }
+        
+        let alignment = max(MemoryLayout<Chunk>.alignment, kDefaultPageAlignment)
+        let stride = chunkBytes + MemoryLayout<Chunk>.stride
+        let newBytes = additionalChunks * stride
+        let newMemory = UnsafeMutableRawPointer.allocate(bytes: newBytes, alignedTo: alignment)
+        
+        var first: UnsafeMutablePointer<Chunk>?
+        var last: UnsafeMutablePointer<Chunk>?
+        
+        for i in 0..<additionalChunks {
+            // get chunk
+            let chunk = newMemory.advanced(by: i * stride).bindMemory(to: Chunk.self, capacity: 1)
+            
+            // initialize chunk
+            chunk.initialize(to: Chunk(next: last))
+            
+            // keep track of the first and last chunk
+            if i == 0 {
+                first = chunk
+            }
+            last = chunk
+        }
+        
+        // insert
+        first?.pointee.next = firstFree
+        firstFree = last
+    }
+    
+    func allocate() -> UnsafeMutableRawPointer? {
+        guard let free = firstFree else { return nil }
+        
+        // memory to return
+        let memory = UnsafeMutableRawPointer(free).advanced(by: MemoryLayout<Chunk>.stride)
+        
+        // update first free
+        firstFree = free.pointee.next
+        
+        return memory
+    }
+    
+    func allocateOrExtend() -> UnsafeMutableRawPointer {
+        
+        // use existing
+        if let memory = allocate() {
+            return memory
+        }
+        
+        // try extending
+        extendBy(additionalChunks: 16)
+        
+        return allocate()!
+    }
+    
+    func free(memory: UnsafeMutableRawPointer) {
+        // find memory header
+        let chunk = memory.advanced(by: 0 - MemoryLayout<Chunk>.stride).assumingMemoryBound(to: Chunk.self)
+        
+        // insert into first free list
+        let lastFree = firstFree
+        firstFree = chunk
+        firstFree?.pointee.next = lastFree
     }
 }
 
-private func ==(lhs: MemorySignature, rhs: MemorySignature) -> Bool {
-    return lhs.length == rhs.length && lhs.size == rhs.size
+internal final class AllocatorSimpleSegregatedStorage: Allocator
+{
+    private let pages1K = AllocatorPage(chunkBytes: 1_024)
+    private let pages4K = AllocatorPage(chunkBytes: 4_096)
+    private let pages32K = AllocatorPage(chunkBytes: 32_768)
+    
+    private func getPage(bytes: Int) -> AllocatorPage? {
+        if bytes <= 1_024 {
+            return pages1K
+        }
+        if bytes <= 4_096 {
+            return pages4K
+        }
+        if bytes <= 32_768 {
+            return pages32K
+        }
+        return nil
+    }
+    
+    func allocateMemory(bytes: Int, alignment: Int) -> UnsafeMutableRawPointer {
+        guard let page = getPage(bytes: bytes) else { fatalError("Unsupported memory size.") }
+        return page.allocateOrExtend()
+    }
+    
+    func deallocateMemory(pointer: UnsafeMutableRawPointer, bytes: Int, alignment: Int) {
+        guard let page = getPage(bytes: bytes) else { fatalError("Unsupported memory size.") }
+        page.free(memory: pointer)
+    }
 }
 
-internal final class AllocatorSimpleSegregatedStorage
-{
-    private var memoryBlocks = [MemorySignature: Array<UnsafeMutableRawPointer>]()
-    private var totalMemory = 0
-    private var maxMemory = 134217728 // 128MB
-    
-    var queue = DispatchQueue(label: "com.MaxMo.VectorMath.MemoryRecycle")
-    
-    func findMemory(length: Int, size: Int) -> UnsafeMutableRawPointer? {
-        let sig = MemorySignature(length: length, size: size)
-        return queue.sync {
-            guard nil != memoryBlocks[sig] else { return nil }
-            guard let ret = memoryBlocks[sig]!.popLast() else { return nil }
-            
-            // update total memory used
-            totalMemory -= sig.totalSize
-            
-            return ret
-        }
-    }
-    
-    func recycleMemory(pointer ptr: UnsafeMutableRawPointer, length: Int, size: Int) {
-        let sig = MemorySignature(length: length, size: size)
-        queue.sync {
-            // at / above threshold?
-            if totalMemory >= maxMemory {
-                ptr.deallocate(bytes: sig.totalSize, alignedTo: MemoryLayout<Float>.alignment)
-                return
-            }
-            
-            // create placeholder
-            if nil == memoryBlocks[sig] {
-                memoryBlocks[sig] = Array<UnsafeMutableRawPointer>()
-            }
-            
-            // add to memory blocks
-            memoryBlocks[sig]!.append(ptr)
-            totalMemory += sig.totalSize
-        }
-    }
-    
-    func setMaximumMemory(_ bytes: Int) {
-        queue.sync {
-            maxMemory = bytes
-            if totalMemory > maxMemory {
-                memoryBlocks.forEach {
-                    key, list in
-                    
-                    let totalSize = key.totalSize
-                    list.forEach {
-                        $0.deallocate(bytes: totalSize, alignedTo: MemoryLayout<Float>.alignment)
-                    }
-                }
-                memoryBlocks.removeAll()
-            }
-        }
-    }
-}

--- a/VectorMath/Internal/Allocators/SimpleSegregatedStorage.swift
+++ b/VectorMath/Internal/Allocators/SimpleSegregatedStorage.swift
@@ -1,9 +1,9 @@
 //
-//  MemoryRecylcing.swift
+//  SimpleSegregatedStorage.swift
 //  VectorMath
 //
-//  Created by Nathan Perkins on 6/26/16.
-//  Copyright © 2016 MaxMo Technologies LLC. All rights reserved.
+//  Created by Nathan Perkins on 1/22/17.
+//  Copyright © 2017 MaxMo Technologies LLC. All rights reserved.
 //
 
 import Foundation
@@ -26,7 +26,7 @@ private func ==(lhs: MemorySignature, rhs: MemorySignature) -> Bool {
     return lhs.length == rhs.length && lhs.size == rhs.size
 }
 
-internal class MemoryRecycling
+internal final class AllocatorSimpleSegregatedStorage
 {
     private var memoryBlocks = [MemorySignature: Array<UnsafeMutableRawPointer>]()
     private var totalMemory = 0
@@ -52,7 +52,7 @@ internal class MemoryRecycling
         queue.sync {
             // at / above threshold?
             if totalMemory >= maxMemory {
-                ptr.deallocateCapacity(sig.totalSize)
+                ptr.deallocate(bytes: sig.totalSize, alignedTo: MemoryLayout<Float>.alignment)
                 return
             }
             
@@ -76,7 +76,7 @@ internal class MemoryRecycling
                     
                     let totalSize = key.totalSize
                     list.forEach {
-                        $0.deallocateCapacity(totalSize)
+                        $0.deallocate(bytes: totalSize, alignedTo: MemoryLayout<Float>.alignment)
                     }
                 }
                 memoryBlocks.removeAll()

--- a/VectorMath/Internal/CircularMemory.swift
+++ b/VectorMath/Internal/CircularMemory.swift
@@ -50,7 +50,7 @@ final class CircularMemory<T>
         self.maxLength = maxLength
         
         // length in bytes
-        let maxBytes = MemoryLayout<T>.size * maxLength
+        let maxBytes = MemoryLayout<T>.stride * maxLength
         
         // create buffer
         buffer = TPCircularBuffer()
@@ -65,11 +65,11 @@ final class CircularMemory<T>
     }
     
     private func countToBytes(count: Int) -> Int {
-        return count * MemoryLayout<T>.size
+        return count * MemoryLayout<T>.stride
     }
     
     private func bytesToCount(bytes: Int) -> Int {
-        return bytes / MemoryLayout<T>.size
+        return bytes / MemoryLayout<T>.stride
     }
     
     /// Buffer for reading data from the tail of the circular buffer. Returns nil if there is no data.
@@ -125,7 +125,7 @@ final class CircularMemory<T>
     
     func produce(data: ManagedMemory<T>) throws {
         // calculate number of bytes
-        let bytes = data.length * MemoryLayout<T>.size
+        let bytes = countToBytes(count: data.length)
         
         // produce bytes
         if !TPCircularBufferProduceBytes(&buffer, data.memory, Int32(bytes)) {

--- a/VectorMath/Internal/ManagedMemory.swift
+++ b/VectorMath/Internal/ManagedMemory.swift
@@ -46,7 +46,7 @@ final class ManagedMemory<T>: Memory {
     
     init(unfilledOfLength length: Int, withAlignment align: Int) {
         self.length = length
-        self.bytes = length * MemoryLayout<T>.size
+        self.bytes = length * MemoryLayout<T>.stride
         self.alignment = align
         
         // allocate alligned memory

--- a/VectorMath/Internal/MemoryRecylcing.swift
+++ b/VectorMath/Internal/MemoryRecylcing.swift
@@ -1,0 +1,86 @@
+//
+//  MemoryRecylcing.swift
+//  VectorMath
+//
+//  Created by Nathan Perkins on 6/26/16.
+//  Copyright © 2016 MaxMo Technologies LLC. All rights reserved.
+//
+
+import Foundation
+
+private struct MemorySignature: Equatable, Hashable
+{
+    let length: Int
+    let size: Int
+    
+    var hashValue: Int {
+        return length.hashValue ^ size.hashValue
+    }
+    
+    var totalSize: Int {
+        return length * size
+    }
+}
+
+private func ==(lhs: MemorySignature, rhs: MemorySignature) -> Bool {
+    return lhs.length == rhs.length && lhs.size == rhs.size
+}
+
+internal class MemoryRecycling
+{
+    private var memoryBlocks = [MemorySignature: Array<UnsafeMutableRawPointer>]()
+    private var totalMemory = 0
+    private var maxMemory = 134217728 // 128MB
+    
+    var queue = DispatchQueue(label: "com.MaxMo.VectorMath.MemoryRecycle")
+    
+    func findMemory(length: Int, size: Int) -> UnsafeMutableRawPointer? {
+        let sig = MemorySignature(length: length, size: size)
+        return queue.sync {
+            guard nil != memoryBlocks[sig] else { return nil }
+            guard let ret = memoryBlocks[sig]!.popLast() else { return nil }
+            
+            // update total memory used
+            totalMemory -= sig.totalSize
+            
+            return ret
+        }
+    }
+    
+    func recycleMemory(pointer ptr: UnsafeMutableRawPointer, length: Int, size: Int) {
+        let sig = MemorySignature(length: length, size: size)
+        queue.sync {
+            // at / above threshold?
+            if totalMemory >= maxMemory {
+                ptr.deallocateCapacity(sig.totalSize)
+                return
+            }
+            
+            // create placeholder
+            if nil == memoryBlocks[sig] {
+                memoryBlocks[sig] = Array<UnsafeMutableRawPointer>()
+            }
+            
+            // add to memory blocks
+            memoryBlocks[sig]!.append(ptr)
+            totalMemory += sig.totalSize
+        }
+    }
+    
+    func setMaximumMemory(_ bytes: Int) {
+        queue.sync {
+            maxMemory = bytes
+            if totalMemory > maxMemory {
+                memoryBlocks.forEach {
+                    key, list in
+                    
+                    let totalSize = key.totalSize
+                    list.forEach {
+                        $0.deallocateCapacity(totalSize)
+                    }
+                }
+                memoryBlocks.removeAll()
+            }
+        }
+    }
+}

--- a/VectorMath/Types/Vectors/VectorDouble.swift
+++ b/VectorMath/Types/Vectors/VectorDouble.swift
@@ -56,7 +56,7 @@ public struct VectorDouble: Vector, VectorSummarizable, VectorArithmetic, Vector
         // copy elements
         var elements = elements
         let _ = withUnsafePointer(to: &elements[0]) {
-            memcpy(memory[0], $0, MemoryLayout<Element>.size * elements.count)
+            memcpy(memory[0], $0, MemoryLayout<Element>.stride * elements.count)
         }
     }
     
@@ -65,7 +65,7 @@ public struct VectorDouble: Vector, VectorSummarizable, VectorArithmetic, Vector
         memory = ManagedMemory<Element>(unfilledOfLength: length)
         
         // copy
-        memcpy(memory[0], ptr, MemoryLayout<Element>.size * length)
+        memcpy(memory[0], ptr, MemoryLayout<Element>.stride * length)
     }
     
     // PRIVATE

--- a/VectorMath/Types/Vectors/VectorFloat.swift
+++ b/VectorMath/Types/Vectors/VectorFloat.swift
@@ -56,7 +56,7 @@ public struct VectorFloat: Vector, VectorSummarizable, VectorArithmetic, VectorM
         // copy elements
         var elements = elements
         let _ = withUnsafePointer(to: &elements[0]) {
-            memcpy(memory[0], $0, MemoryLayout<Element>.size * elements.count)
+            memcpy(memory[0], $0, MemoryLayout<Element>.stride * elements.count)
         }
     }
     
@@ -65,7 +65,7 @@ public struct VectorFloat: Vector, VectorSummarizable, VectorArithmetic, VectorM
         memory = ManagedMemory<Element>(unfilledOfLength: length)
         
         // copy
-        memcpy(memory[0], ptr, MemoryLayout<Element>.size * length)
+        memcpy(memory[0], ptr, MemoryLayout<Element>.stride * length)
     }
     
     // PRIVATE

--- a/VectorMath/Types/Vectors/VectorInteger32.swift
+++ b/VectorMath/Types/Vectors/VectorInteger32.swift
@@ -57,7 +57,7 @@ public struct VectorInteger32: Vector, VectorSummarizable, VectorArithmetic, Vec
         // copy elements
         var elements = elements
         let _ = withUnsafePointer(to: &elements[0]) {
-            memcpy(memory[0], $0, MemoryLayout<Element>.size * elements.count)
+            memcpy(memory[0], $0, MemoryLayout<Element>.stride * elements.count)
         }
     }
     
@@ -66,7 +66,7 @@ public struct VectorInteger32: Vector, VectorSummarizable, VectorArithmetic, Vec
         memory = ManagedMemory<Element>(unfilledOfLength: length)
         
         // copy
-        memcpy(memory[0], ptr, MemoryLayout<Element>.size * length)
+        memcpy(memory[0], ptr, MemoryLayout<Element>.stride * length)
     }
     
     // PRIVATE

--- a/VectorMathTests/Types/VectorInteger32Tests.swift
+++ b/VectorMathTests/Types/VectorInteger32Tests.swift
@@ -65,7 +65,7 @@ class VectorInteger32Tests: XCTestCase {
         
         vector += 5
         for (i, j) in vector.enumerated() {
-            XCTAssertEqual(Int32(i) + 5, j)
+            XCTAssertEqual(Int32(i) + Int32(5), j)
         }
     }
     


### PR DESCRIPTION
Generalize the allocation scheme to potential attempt other mechanisms for allocation / deallocation, especially in light of the fact that many implementations will resume similar length chunks of memory as intermediaries.

A simple attempt at segregated storage in Swift does not show any performance benefit though. Likely the underlying system allocators and deallocators will be more efficient. But keep the infrastructure in place just in case.